### PR TITLE
Changed the text and background colors in the ocaml-merlin-bubble

### DIFF
--- a/styles/ocaml-merlin.atom-text-editor.less
+++ b/styles/ocaml-merlin.atom-text-editor.less
@@ -7,8 +7,8 @@
 }
 
 #ocaml-merlin-bubble {
-  color: @base-background-color;
-  background: fade(@background-color-info, 90%);
+  color: darken(@text-color-info, 40%);
+  background-color: fade(lighten(@background-color-info, 10%), 90%);
   border-radius: 0 2*@space 2*@space 2*@space;
   padding: @space 2*@space;
   margin-top: @space;


### PR DESCRIPTION
Before, what was written in the bubble was not legible, at least in the theme I use, as the text had almost the same color as the background. Now it's much better.

I imagine that in other themes this problem didn't appear, probably text of @base-background-color looked fine on the background of @background-color-info, or otherwise someone would notice the problem before. I hope that text of @text-color-info will look good on the background @background-color-info in any theme. I assume that the "-color-info" suffix in color names means that these two are supposed to be used together.
