### PR TITLE
Set merlin's cwd to the project root

### DIFF
--- a/lib/merlin.coffee
+++ b/lib/merlin.coffee
@@ -17,7 +17,9 @@ module.exports = class Merlin
     path = atom.config.get 'ocaml-merlin.merlinPath'
     @interface?.close()
     @process?.kill()
-    @process = spawn path
+
+    projectPaths = atom.project.getPaths()
+    @process = spawn path, [], cwd: if projectPaths.length > 0 then projectPaths[0] else __dirname
     @process.on 'error', (error) -> console.log error
     @process.on 'exit', (code) -> console.log "Merlin exited with code #{code}"
     console.log "Merlin process started, pid = #{@process.pid}"


### PR DESCRIPTION
:wave: 

This allows a Merlin config like the following, to support languages like [BuckleScript](https://github.com/bloomberg/bucklescript):

```
FLG -ppx node_modules/bs-platform/bin/bsppx.exe
```

Without this, Merlin won’t be able to find BuckleScript and will error as soon as we request anything from it.

Alternatively, users would have to provide an absolute path which means they couldn’t shared it between users.