### PR TITLE
Add support for the language-ocaml-fix package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "merlin"
   ],
   "activationHooks": [
-    "language-ocaml:grammar-used"
+    "language-ocaml:grammar-used",
+    "language-ocaml-fix:grammar-used"
   ],
   "repository": "https://github.com/314eter/atom-ocaml-merlin",
   "license": "MIT",


### PR DESCRIPTION
This PR adds an activation hook for an active fork of [language-ocaml](https://github.com/toroidal-code/language-ocaml).